### PR TITLE
docs: add Phase A canon governance documentation

### DIFF
--- a/docs/canon/ATTACHMENT_PACKAGING_STRATEGY.md
+++ b/docs/canon/ATTACHMENT_PACKAGING_STRATEGY.md
@@ -1,0 +1,453 @@
+# Attachment Packaging Strategy
+
+**Phase:** A (Canonisation)
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON
+**Repository:** claude-code-showcase (Statera-Jason)
+**Status:** Authoritative
+**Version:** 1.0.0
+
+---
+
+## Purpose
+
+This document defines the permitted patterns for attaching the claude-code-showcase foundation to other projects, the bounded footprint rules, and how upgrade and divergence are handled.
+
+---
+
+## Core Principle: Bounded Footprint
+
+All attachment methods MUST maintain a **bounded footprint** within adopting projects:
+
+- Configuration must be isolated to known directories (`.claude/`, `docs/`, etc.)
+- No scattered configuration files throughout project structure
+- No modification of existing project files without explicit action
+- Clear separation between foundation patterns and project code
+
+**Why:** Enables clean detachment and prevents deep coupling.
+
+---
+
+## Permitted Attachment Patterns
+
+### Pattern 1: Direct Copy (Recommended)
+
+**Method:** Copy files directly into target project repository
+
+```bash
+# Example attachment via direct copy
+cd target-project/
+
+# Copy core configuration
+cp -r /path/to/claude-code-showcase/.claude .
+cp /path/to/claude-code-showcase/CLAUDE.md .
+cp /path/to/claude-code-showcase/.mcp.json .
+
+# Optionally copy GitHub workflows
+cp -r /path/to/claude-code-showcase/.github/workflows .github/
+
+# Customize for project
+# Edit CLAUDE.md, skills, commands, etc.
+```
+
+**Characteristics:**
+- ✓ Full control over files
+- ✓ Easy to customize
+- ✓ No external dependencies
+- ✓ Simple version control
+- ✗ No automatic updates
+- ✗ Manual synchronization required
+
+**Best For:**
+- Projects that will heavily customize
+- Teams that want full ownership
+- Long-term stable configurations
+
+**Footprint:**
+```
+target-project/
+├── .claude/              # Bounded directory
+├── CLAUDE.md             # Single file
+├── .mcp.json             # Single file
+└── .github/workflows/    # Opt-in directory
+```
+
+---
+
+### Pattern 2: Git Subtree (Advanced)
+
+**Method:** Merge foundation as a subtree in project repository
+
+```bash
+# Initial setup
+cd target-project/
+git subtree add --prefix=.claude-foundation \
+  https://github.com/Statera-Jason/claude-code-showcase.git main --squash
+
+# Create symlinks to active configuration
+ln -s .claude-foundation/.claude .claude
+ln -s .claude-foundation/CLAUDE.md CLAUDE.md.template
+
+# Later: Pull updates
+git subtree pull --prefix=.claude-foundation \
+  https://github.com/Statera-Jason/claude-code-showcase.git main --squash
+```
+
+**Characteristics:**
+- ✓ Preserves update path
+- ✓ Full history tracking
+- ✓ Can push improvements back
+- ✗ More complex to manage
+- ✗ Requires git subtree knowledge
+- ✗ Can cause merge conflicts
+
+**Best For:**
+- Projects tracking foundation updates
+- Teams comfortable with git subtree
+- Projects planning to contribute back
+
+**Footprint:**
+```
+target-project/
+├── .claude-foundation/   # Bounded subtree directory
+├── .claude -> .claude-foundation/.claude  # Symlink
+└── CLAUDE.md.template -> .claude-foundation/CLAUDE.md
+```
+
+---
+
+### Pattern 3: Vendor Copy (Isolated Updates)
+
+**Method:** Copy to vendor directory, reference from configuration
+
+```bash
+# Copy to vendor
+cd target-project/
+mkdir -p vendor/claude-foundation
+cp -r /path/to/claude-code-showcase/.claude vendor/claude-foundation/
+cp /path/to/claude-code-showcase/CLAUDE.md vendor/claude-foundation/
+
+# Create project-specific configuration that extends vendored patterns
+mkdir -p .claude/skills
+cat > .claude/settings.json <<EOF
+{
+  "hooks": {
+    "_import": "../vendor/claude-foundation/.claude/settings.json"
+  }
+}
+EOF
+```
+
+**Characteristics:**
+- ✓ Clear separation: vendor vs project
+- ✓ Preserves original patterns
+- ✓ Easy to compare changes
+- ✗ Requires configuration composition
+- ✗ May not support imports (manual merge needed)
+
+**Best For:**
+- Projects with strict vendoring policies
+- Organizations tracking third-party code
+- Compliance-heavy environments
+
+**Footprint:**
+```
+target-project/
+├── vendor/
+│   └── claude-foundation/  # Bounded vendor directory
+├── .claude/                # Project-specific overrides
+└── CLAUDE.md               # Project-specific content
+```
+
+---
+
+## Prohibited Attachment Patterns
+
+The following patterns are **PROHIBITED** as they violate bounded footprint principles:
+
+### ❌ Scattered Configuration
+
+```
+# PROHIBITED - Configuration scattered throughout project
+target-project/
+├── src/components/.claude-component-rules
+├── src/api/.claude-api-rules
+├── tests/.claude-test-rules
+└── docs/.claude-docs-rules
+```
+
+**Why Prohibited:** Makes detachment difficult, creates maintenance burden, unclear scope.
+
+---
+
+### ❌ Package Manager Dependency
+
+```json
+// PROHIBITED - Foundation as npm/pip/gem dependency
+{
+  "dependencies": {
+    "claude-code-showcase": "github:Statera-Jason/claude-code-showcase"
+  }
+}
+```
+
+**Why Prohibited:** Foundation is configuration, not executable code. Not suitable for package management.
+
+---
+
+### ❌ Remote Reference Without Local Copy
+
+```json
+// PROHIBITED - Loading remote configuration at runtime
+{
+  "claude": {
+    "skills": [
+      "https://raw.githubusercontent.com/.../SKILL.md"
+    ]
+  }
+}
+```
+
+**Why Prohibited:** Creates external runtime dependency, network failures break functionality, no version control.
+
+---
+
+### ❌ Automatic Code Injection
+
+```bash
+# PROHIBITED - Modifying project files automatically
+./attach-foundation.sh --inject-hooks --modify-gitignore --update-readme
+```
+
+**Why Prohibited:** Violates explicit consent, makes changes hard to track, difficult to reverse.
+
+---
+
+## Bounded Footprint Rules
+
+### Rule 1: Isolated Directories
+
+Foundation configuration MUST be contained in:
+
+```
+Permitted directories:
+- .claude/           # Primary configuration
+- CLAUDE.md          # Root-level file (single file only)
+- .mcp.json          # Root-level file (single file only)
+- .github/workflows/ # Opt-in workflows (clearly named)
+- docs/canon/        # Governance documents (if adopted)
+- vendor/*/          # Vendor directory (if using Pattern 3)
+```
+
+No configuration may exist outside these boundaries without explicit documentation.
+
+### Rule 2: No Hidden Dependencies
+
+Foundation configuration MUST NOT:
+
+- Require specific project directory structure
+- Assume specific file locations outside `.claude/`
+- Depend on undocumented environment variables
+- Require specific npm packages without declaring them
+
+### Rule 3: Detachment in One Step
+
+It MUST be possible to detach by:
+
+```bash
+# Complete detachment
+rm -rf .claude/ CLAUDE.md .mcp.json docs/canon/
+
+# Or selective removal
+rm -rf .claude/hooks/        # Remove just hooks
+rm -rf .claude/skills/       # Remove just skills
+```
+
+No manual cleanup or "uninstall" scripts should be required.
+
+### Rule 4: No Project File Modification
+
+Foundation MUST NOT require:
+
+- Modifying `.gitignore` (except to add `.claude/settings.local.json`)
+- Modifying `package.json` (except to add optional dependencies)
+- Modifying build configuration
+- Modifying CI/CD pipelines (except explicitly added workflows)
+
+All changes MUST be opt-in and reversible.
+
+---
+
+## Upgrade Handling
+
+### Upgrade Strategy: Pull-Based
+
+Projects control when and how they upgrade:
+
+1. **Manual Comparison:**
+   ```bash
+   # Compare local vs foundation
+   diff -r .claude/ /path/to/claude-code-showcase/.claude/
+   ```
+
+2. **Selective Adoption:**
+   ```bash
+   # Copy only desired updates
+   cp /path/to/claude-code-showcase/.claude/skills/new-skill/ .claude/skills/
+   ```
+
+3. **Full Refresh:**
+   ```bash
+   # Backup customizations
+   mv .claude .claude.backup
+
+   # Copy latest foundation
+   cp -r /path/to/claude-code-showcase/.claude .
+
+   # Restore customizations
+   # Manually merge .claude.backup with new .claude
+   ```
+
+### Upgrade Compatibility
+
+Foundation updates SHOULD maintain:
+
+- ✓ Backwards compatibility within major version
+- ✓ Deprecation notices for breaking changes
+- ✓ Migration guides for major versions
+
+Foundation updates MAY break:
+
+- Custom modifications not in contract
+- Undocumented feature usage
+- Workarounds for defects after fixes
+
+### Upgrade Communication
+
+Foundation will communicate updates via:
+
+- GitHub releases with changelogs
+- Breaking changes in major version bumps
+- Deprecation warnings in documentation
+
+Foundation will NOT:
+
+- Automatically update adopting projects
+- Push breaking changes without major version
+- Remove capabilities without deprecation period
+
+---
+
+## Divergence Handling
+
+### Permitted Divergence
+
+Projects MAY diverge by:
+
+1. **Adding capabilities:**
+   - New skills for project-specific patterns
+   - New commands for project workflows
+   - New agents for project needs
+   - Additional MCP servers
+
+2. **Modifying capabilities:**
+   - Customizing skill content
+   - Adjusting hook timeouts
+   - Changing command logic
+   - Updating agent checklists
+
+3. **Removing capabilities:**
+   - Deleting unused skills
+   - Disabling hooks
+   - Removing MCP servers
+   - Excluding GitHub Actions
+
+4. **Fixing defects:**
+   - Workarounds for DEF-001 (bash/sh)
+   - Environment-specific adjustments
+   - Performance optimizations
+
+### Documenting Divergence
+
+Projects SHOULD document divergence:
+
+```markdown
+<!-- In .claude/README.md -->
+## Divergence from claude-code-showcase
+
+### Modifications
+- skills/testing-patterns: Adapted for Playwright instead of Jest
+- hooks: Converted to POSIX sh for compatibility (DEF-001 workaround)
+
+### Additions
+- skills/kubernetes-patterns: Added for K8s deployments
+- commands/deploy: Added for deployment workflow
+
+### Removals
+- skills/graphql-schema: Not applicable (REST API only)
+- agents/github-workflow: Using custom git workflow
+```
+
+### Reconciliation
+
+Projects are NOT required to:
+
+- Reconcile divergence with upstream
+- Merge foundation updates
+- Maintain compatibility after divergence
+
+Projects that heavily diverge have **effectively detached** and should consider:
+
+- Removing attribution if no longer recognizable
+- Forking foundation for their organization
+- Creating their own governance
+
+---
+
+## Footprint Validation
+
+### Validation Checklist
+
+Verify bounded footprint with:
+
+```bash
+# Check for scattered configuration
+find . -name ".claude*" -not -path "./.claude/*" -not -path "./.git/*"
+
+# Check for unexpected files
+ls -la | grep -E "(claude|CLAUDE)" | grep -v "^d.*\.claude$" | grep -v "^-.*CLAUDE\.md$"
+
+# Verify detachment is clean
+rm -rf .claude/ CLAUDE.md .mcp.json && git status
+```
+
+Expected result: Only known files in known locations.
+
+### Compliance Criteria
+
+A compliant attachment:
+
+- [ ] All configuration in permitted directories
+- [ ] No scattered configuration files
+- [ ] No modifications to existing project files (except opt-in)
+- [ ] Detachment possible in one step
+- [ ] No hidden dependencies
+- [ ] Documentation of divergence (if applicable)
+
+---
+
+## Acceptance Criteria
+
+This strategy is complete when:
+
+1. ✓ Permitted patterns are defined (3 patterns)
+2. ✓ Prohibited patterns are explicit
+3. ✓ Bounded footprint rules are clear
+4. ✓ Upgrade strategy is documented
+5. ✓ Divergence handling is defined
+6. ✓ Validation methods are provided
+
+---
+
+**Document Status:** COMPLETE
+**Last Updated:** 2026-01-09
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON

--- a/docs/canon/CLAUDE_FOUNDATION_CAPABILITIES_REGISTER.md
+++ b/docs/canon/CLAUDE_FOUNDATION_CAPABILITIES_REGISTER.md
@@ -1,0 +1,422 @@
+# Claude Foundation Capabilities Register
+
+**Phase:** A (Canonisation)
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON
+**Repository:** claude-code-showcase (Statera-Jason)
+**Status:** Authoritative
+**Version:** 1.0.0
+
+---
+
+## Purpose
+
+This register enumerates all capabilities present in the claude-code-showcase repository, their locations, default states, dependencies, risks, and approved extension paths.
+
+---
+
+## Capability Classification
+
+| Status | Definition |
+|--------|------------|
+| **Enabled** | Active by default, requires no configuration |
+| **Disabled** | Present but inactive by default, requires explicit enablement |
+| **Dormant** | Complete implementation present, intentionally inactive, requires governance approval |
+| **Template** | Reference implementation only, requires customization before use |
+
+---
+
+## Core Capabilities
+
+### CAP-001: Project Memory (CLAUDE.md)
+
+**Location:** `/CLAUDE.md`
+
+**Status:** Enabled
+
+**Description:** Persistent project memory loaded at session start containing stack information, conventions, and critical rules.
+
+**Dependencies:**
+- None
+
+**Risks:**
+- Low: Read-only documentation
+
+**Extension Path:**
+- Adopting projects should customize content to reflect their stack, conventions, and rules
+- File location can be `.claude/CLAUDE.md`, `./CLAUDE.md`, or `~/.claude/CLAUDE.md`
+
+**Notes:**
+- Automatically loaded by Claude Code at session initialization
+
+---
+
+### CAP-002: Hook Configuration
+
+**Location:** `.claude/settings.json`
+
+**Status:** Template
+
+**Description:** Hook-based automation for code formatting, testing, type-checking, and branch protection.
+
+**Sub-capabilities:**
+- **CAP-002a:** UserPromptSubmit hooks (skill evaluation)
+- **CAP-002b:** PreToolUse hooks (branch protection)
+- **CAP-002c:** PostToolUse hooks (formatting, testing, type-checking)
+
+**Dependencies:**
+- Bash shell (known issue: requires bash, not sh)
+- npm ecosystem
+- prettier or biome (formatting)
+- jest (testing)
+- TypeScript (type checking)
+
+**Risks:**
+- **HIGH - Known Defect:** Hooks use bash-specific syntax (`[[`, `=~`) but system may execute with `/bin/sh`
+  - Status: Documented issue
+  - Impact: Hook failures in sh-only environments
+  - Mitigation: Deferred to later phase
+  - Workaround: Use bash-compatible shell or rewrite hooks for POSIX compliance
+
+- Medium: Hook failures can block workflow
+- Medium: Timeout configuration may need tuning
+- Low: npm commands may fail without dependencies installed
+
+**Extension Path:**
+- Copy `.claude/settings.json` to target project
+- Customize matchers, commands, and timeouts for project needs
+- Add or remove hooks as needed
+- Configure environment variables in `env` section
+- Test hooks in target environment before committing
+
+**Notes:**
+- Hook exit code 2 blocks actions (PreToolUse only)
+- Hook exit code 0 or 1 is non-blocking
+- Hooks receive environment variables: `$CLAUDE_TOOL_INPUT_FILE_PATH`, `$CLAUDE_TOOL_NAME`, `$CLAUDE_PROJECT_DIR`
+
+---
+
+### CAP-003: Skill Evaluation System
+
+**Location:** `.claude/hooks/`
+
+**Files:**
+- `skill-eval.sh` - Wrapper script
+- `skill-eval.js` - Node.js matching engine
+- `skill-rules.json` - Pattern matching rules
+- `skill-rules.schema.json` - JSON schema for rules
+
+**Status:** Template
+
+**Description:** Automated skill suggestion system that analyzes prompts for keywords, file paths, and patterns to recommend relevant skills.
+
+**Dependencies:**
+- Node.js runtime
+- Bash shell
+- UserPromptSubmit hook configuration
+
+**Risks:**
+- Low: False positive skill suggestions
+- Low: Performance impact on prompt submission (<5s timeout)
+- Medium: Requires maintenance as skills evolve
+
+**Extension Path:**
+1. Copy `.claude/hooks/` directory to target project
+2. Customize `skill-rules.json` with project-specific skills
+3. Adjust trigger patterns (keywords, regexes, paths)
+4. Configure confidence thresholds and priorities
+5. Add UserPromptSubmit hook to `settings.json`
+
+**Notes:**
+- Confidence scoring: keyword=2, keywordPattern=3, pathPattern=4, directoryMatch=5, intentPattern=4
+- Threshold: 6+ points = HIGH, 4-5 = MEDIUM, <4 = not suggested
+
+---
+
+### CAP-004: Domain Knowledge Skills
+
+**Location:** `.claude/skills/`
+
+**Status:** Template
+
+**Available Skills:**
+- `testing-patterns` - Jest, TDD, factory functions, mocking
+- `systematic-debugging` - Four-phase debugging methodology
+- `react-ui-patterns` - Loading, error, empty states
+- `graphql-schema` - Queries, mutations, code generation
+- `core-components` - Design system and component library
+- `formik-patterns` - Form handling and validation
+
+**Dependencies:**
+- Project-specific: Each skill assumes certain technologies/patterns
+
+**Risks:**
+- Low: Skills may not match adopting project's tech stack
+- Low: Skills may become outdated as patterns evolve
+
+**Extension Path:**
+1. Copy relevant skill directories to target project
+2. Customize SKILL.md content for project-specific patterns
+3. Update frontmatter (name, description)
+4. Add project-specific examples
+5. Remove or modify patterns that don't apply
+6. Create new skills for project-specific domains
+
+**Notes:**
+- SKILL.md must have YAML frontmatter with `name` and `description`
+- Description is critical for Claude's semantic matching
+- Maximum frontmatter field lengths: name=64, description=1024
+
+---
+
+### CAP-005: Specialized Agents
+
+**Location:** `.claude/agents/`
+
+**Status:** Template
+
+**Available Agents:**
+- `code-reviewer.md` - Comprehensive code review with checklist
+- `github-workflow.md` - Git operations, branches, commits, PRs
+
+**Dependencies:**
+- Project-specific: Code reviewer assumes project standards exist
+- git, gh CLI (github-workflow agent)
+
+**Risks:**
+- Low: Agent prompts may need customization for project standards
+
+**Extension Path:**
+1. Copy agent markdown files to target project
+2. Customize agent system prompts
+3. Update checklists and processes for project standards
+4. Modify allowed tools if needed
+5. Adjust model selection (sonnet/opus/haiku)
+
+**Notes:**
+- Agents are autonomous and have dedicated prompts
+- Agent frontmatter: name, description, model (optional), tools (optional)
+
+---
+
+### CAP-006: Slash Commands
+
+**Location:** `.claude/commands/`
+
+**Status:** Template
+
+**Available Commands:**
+- `/onboard` - Deep task exploration and planning
+- `/ticket` - JIRA/Linear ticket workflow (read → implement → update)
+- `/pr-review` - Pull request review workflow
+- `/pr-summary` - Generate PR description from git diff
+- `/code-quality` - Code quality checks on directory
+- `/docs-sync` - Documentation alignment verification
+
+**Dependencies:**
+- Command-specific: `/ticket` requires MCP servers (JIRA/Linear)
+- git, gh CLI (PR commands)
+
+**Risks:**
+- Medium: `/ticket` command requires MCP server configuration
+- Low: Commands may need project-specific customization
+
+**Extension Path:**
+1. Copy command markdown files to target project
+2. Customize command instructions for project workflows
+3. Update allowed-tools as needed
+4. Add inline bash commands with `!`
+5. Use `$ARGUMENTS`, `$1`, `$2`, etc. for parameters
+
+**Notes:**
+- Commands are invoked with `/command-name arguments`
+- Command frontmatter: description, allowed-tools (optional)
+
+---
+
+### CAP-007: MCP Server Integration
+
+**Location:** `.mcp.json`
+
+**Status:** Dormant
+
+**Description:** External integrations via Model Context Protocol servers (JIRA, GitHub, Linear, Slack, Sentry, Postgres, Notion, Memory).
+
+**Configured Servers:**
+- `jira` - JIRA integration
+- `github` - GitHub API integration
+- `linear` - Linear issue tracking
+- `sentry` - Error monitoring
+- `postgres` - Database access
+- `slack` - Slack messaging
+- `notion` - Notion workspace
+- `memory` - Persistent memory storage
+
+**Dependencies:**
+- Server-specific: Each MCP server requires API credentials
+- npx (for stdio servers)
+- Environment variables with credentials
+
+**Risks:**
+- **HIGH - Security:** Requires API credentials in environment
+- Medium: MCP servers may not be available or compatible
+- Medium: Cost implications for API usage
+- Low: Server startup latency
+
+**Extension Path:**
+1. Copy `.mcp.json` to target project
+2. Remove unused server configurations
+3. Set required environment variables (never commit credentials)
+4. Configure server enablement in `.claude/settings.json`:
+   - `enableAllProjectMcpServers: true` OR
+   - `enabledMcpjsonServers: ["jira", "github"]`
+5. Test server connectivity before relying on capabilities
+
+**Notes:**
+- Environment variable expansion: `${VAR}` or `${VAR:-default}`
+- Server types: `stdio` (local process) or `http` (remote)
+- All configured servers are dormant by default (require explicit enablement)
+
+---
+
+### CAP-008: GitHub Actions Workflows
+
+**Location:** `.github/workflows/`
+
+**Status:** Disabled
+
+**Description:** Automated CI/CD workflows for PR review, scheduled maintenance, documentation sync, and dependency management.
+
+**Available Workflows:**
+- `pr-claude-code-review.yml` - Automated PR reviews
+- `scheduled-claude-code-docs-sync.yml` - Monthly documentation alignment
+- `scheduled-claude-code-quality.yml` - Weekly code quality reviews
+- `scheduled-claude-code-dependency-audit.yml` - Biweekly dependency updates
+
+**Dependencies:**
+- GitHub repository
+- `ANTHROPIC_API_KEY` secret in repository settings
+- Claude Code Action (`anthropics/claude-code-action@beta`)
+- git, gh CLI
+
+**Risks:**
+- **HIGH - Cost:** API usage costs for Anthropic API ($10-50/month estimated)
+- **HIGH - Governance:** Requires approval for automated commits/PRs
+- Medium: Workflow failures may not be monitored
+- Medium: Rate limiting on GitHub Actions or Anthropic API
+
+**Extension Path:**
+1. Review workflows and customize for project needs
+2. Add `ANTHROPIC_API_KEY` to repository secrets
+3. Test workflows on non-production branches first
+4. Enable workflows by committing to `.github/workflows/`
+5. Monitor costs and adjust schedules as needed
+6. Configure branch protection if automated commits are enabled
+
+**Notes:**
+- **Disabled by default due to cost and governance concerns**
+- Workflows are templates only - require explicit enablement
+- Cost estimates: PR review ($0.05-0.50), Docs sync ($0.50-2.00), Quality ($1-5), Audit ($0.20-1.00)
+
+---
+
+### CAP-009: LSP Plugin Support
+
+**Location:** `.claude/settings.json` (configuration only)
+
+**Status:** Template (configuration present, requires plugin installation)
+
+**Description:** Language Server Protocol integration for real-time code intelligence (type checking, completions, navigation).
+
+**Supported Languages:**
+- TypeScript/JavaScript (`typescript-lsp@claude-plugins-official`)
+- Python (`pyright-lsp@claude-plugins-official`)
+- Rust (`rust-lsp@claude-plugins-official`)
+
+**Dependencies:**
+- Language-specific: TypeScript requires `typescript-language-server` and `typescript` npm packages
+- Project must have language tooling installed
+- Claude Code LSP plugin system
+
+**Risks:**
+- Low: LSP servers may have performance impact
+- Low: Configuration errors may prevent activation
+
+**Extension Path:**
+1. Install language server binaries (e.g., `npm install -g typescript-language-server typescript`)
+2. Enable plugins in `.claude/settings.json`: `"enabledPlugins": {"typescript-lsp@claude-plugins-official": true}`
+3. Optionally create `.lsp.json` for custom configuration
+4. Verify with `claude /plugin` command
+
+**Notes:**
+- LSP provides diagnostics, hover info, completions, and navigation
+- Not all languages have LSP support
+- Some LSP servers require project-specific configuration
+
+---
+
+## Capability Dependencies Matrix
+
+| Capability | Requires | Optional Enhancement |
+|------------|----------|---------------------|
+| CAP-001 (CLAUDE.md) | None | - |
+| CAP-002 (Hooks) | bash, npm | prettier, biome, jest, tsc |
+| CAP-003 (Skill Eval) | Node.js, bash, CAP-002 | CAP-004 (skills) |
+| CAP-004 (Skills) | None | Project-specific tools |
+| CAP-005 (Agents) | None | git, gh CLI |
+| CAP-006 (Commands) | None | git, gh CLI, CAP-007 (MCP) |
+| CAP-007 (MCP) | npx, credentials | Network access |
+| CAP-008 (GitHub Actions) | GitHub repo, API key | Branch protection |
+| CAP-009 (LSP) | Language servers | `.lsp.json` config |
+
+---
+
+## Risk Summary
+
+| Risk Level | Count | Capabilities |
+|------------|-------|--------------|
+| **HIGH** | 3 | CAP-002 (bash/sh mismatch), CAP-007 (credentials), CAP-008 (cost/governance) |
+| **Medium** | 6 | Various operational and maintenance risks |
+| **Low** | 8 | Minor customization and compatibility risks |
+
+---
+
+## Known Defects
+
+### DEF-001: Bash vs Sh Shell Mismatch
+
+**Affected Capability:** CAP-002 (Hook Configuration)
+
+**Description:** Hooks in `.claude/settings.json` use bash-specific syntax (`[[`, `=~`, `${PIPESTATUS[0]}`) but may execute under `/bin/sh` which does not support these features.
+
+**Impact:** Hook failures with syntax errors in sh-only environments
+
+**Status:** Documented, Deferred
+
+**Action:** Not Phase A
+
+**Workaround Options:**
+1. Configure environment to use bash instead of sh
+2. Rewrite hooks for POSIX sh compatibility
+3. Disable problematic hooks in sh environments
+
+**Phase for Resolution:** Phase B or later (requires governance approval)
+
+---
+
+## Acceptance Criteria
+
+This register is complete when:
+
+1. ✓ All capabilities are enumerated with unique identifiers
+2. ✓ Each capability has location, status, description
+3. ✓ Dependencies are documented
+4. ✓ Risks are assessed
+5. ✓ Extension paths are defined
+6. ✓ Known defects are documented
+7. ✓ Dependency matrix is complete
+
+---
+
+**Document Status:** COMPLETE
+**Last Updated:** 2026-01-09
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON

--- a/docs/canon/CLAUDE_FOUNDATION_SCOPE.md
+++ b/docs/canon/CLAUDE_FOUNDATION_SCOPE.md
@@ -1,0 +1,230 @@
+# Claude Foundation Scope
+
+**Phase:** A (Canonisation)
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON
+**Repository:** claude-code-showcase (Statera-Jason)
+**Status:** Authoritative
+**Version:** 1.0.0
+
+---
+
+## Purpose
+
+This document defines the explicit scope boundaries for the claude-code-showcase repository as a foundational governance layer for Statera / Project420. It establishes what is and is not included in Phase A canonisation.
+
+---
+
+## In Scope
+
+### 1. Configuration Patterns
+
+The following configuration patterns are in scope as reference implementations:
+
+- `.claude/settings.json` - Hook configuration, environment variables
+- `.claude/settings.md` - Human-readable hook documentation
+- `CLAUDE.md` - Project memory patterns
+- `.mcp.json` - MCP server configuration patterns
+
+### 2. Domain Knowledge Artifacts
+
+All skill definitions are in scope as templates:
+
+- `.claude/skills/testing-patterns/` - TDD and testing conventions
+- `.claude/skills/systematic-debugging/` - Debugging methodology
+- `.claude/skills/react-ui-patterns/` - UI state handling patterns
+- `.claude/skills/graphql-schema/` - GraphQL conventions
+- `.claude/skills/core-components/` - Component library patterns
+- `.claude/skills/formik-patterns/` - Form handling patterns
+
+### 3. Agent Definitions
+
+Agent patterns are in scope as reference templates:
+
+- `.claude/agents/code-reviewer.md` - Code review checklist and process
+- `.claude/agents/github-workflow.md` - Git workflow automation
+
+### 4. Command Templates
+
+Slash command patterns are in scope:
+
+- `.claude/commands/onboard.md` - Task exploration pattern
+- `.claude/commands/ticket.md` - Ticket workflow pattern
+- `.claude/commands/pr-review.md` - PR review pattern
+- `.claude/commands/pr-summary.md` - PR summary generation
+- `.claude/commands/code-quality.md` - Quality check pattern
+- `.claude/commands/docs-sync.md` - Documentation alignment pattern
+
+### 5. Hook Implementations
+
+Hook patterns for automation are in scope:
+
+- `.claude/hooks/skill-eval.sh` - Skill evaluation wrapper
+- `.claude/hooks/skill-eval.js` - Skill matching engine
+- `.claude/hooks/skill-rules.json` - Pattern matching rules
+- `.claude/hooks/skill-rules.schema.json` - Rule schema definition
+
+### 6. GitHub Actions Templates
+
+Workflow patterns are in scope as templates (off-by-default):
+
+- `.github/workflows/pr-claude-code-review.yml` - PR review automation
+- `.github/workflows/scheduled-claude-code-docs-sync.yml` - Documentation sync
+- `.github/workflows/scheduled-claude-code-quality.yml` - Quality reviews
+- `.github/workflows/scheduled-claude-code-dependency-audit.yml` - Dependency management
+
+### 7. Documentation
+
+Repository documentation is in scope:
+
+- `README.md` - Repository overview and patterns
+- `.claude/skills/README.md` - Skills overview
+
+### 8. Governance Definitions
+
+This canon layer itself is in scope:
+
+- `docs/canon/*.md` - All Phase A governance documents
+
+---
+
+## Out of Scope
+
+### 1. Runtime Behavior
+
+Phase A DOES NOT define or implement:
+
+- How Claude Code executes prompts
+- Runtime decision-making logic
+- Execution orchestration
+- Live agent behavior
+- Dynamic skill activation logic
+
+**Rationale:** Phase A is documentation and structure only. Runtime behavior is deferred to later phases.
+
+### 2. Project-Specific Implementation
+
+Phase A DOES NOT include:
+
+- Actual application code
+- Project-specific business logic
+- Real test suites
+- Real component libraries
+- Real GraphQL schemas
+- Real form implementations
+
+**Rationale:** This repository provides patterns and templates, not actual application code.
+
+### 3. Environment-Specific Configuration
+
+Phase A DOES NOT include:
+
+- Real API credentials
+- Production environment variables
+- User-specific settings
+- Local development overrides (`.local.*` files)
+
+**Rationale:** These are environment-specific and must be provided by adopting projects.
+
+### 4. Claude Prompt Generation
+
+Phase A explicitly FORBIDS:
+
+- Generation of Claude Code prompts
+- Generation of Claude Web prompts
+- Any executable AI instructions targeting Claude models
+
+**Rationale:** Prompt generation is deferred to later phases when explicitly requested.
+
+### 5. Build/Compilation Artifacts
+
+Phase A DOES NOT include:
+
+- Compiled code
+- Built assets
+- Generated types
+- Transpiled JavaScript
+- Bundled dependencies
+
+**Rationale:** These are build-time artifacts, not source governance.
+
+### 6. External System State
+
+Phase A DOES NOT define:
+
+- Actual JIRA projects or tickets
+- GitHub repository state
+- External database schemas
+- Slack workspace configuration
+- Sentry project configuration
+
+**Rationale:** These are external systems beyond repository control.
+
+---
+
+## Explicit Exclusions
+
+The following are EXPLICITLY EXCLUDED from Phase A scope:
+
+### 1. Inference from Absence
+
+If a pattern or capability is not explicitly documented in Phase A canon, it MUST NOT be inferred as prohibited or permitted. Absence does not imply policy.
+
+### 2. Implementation Guidance for Claude
+
+Phase A does not provide guidance on how Claude should interpret or execute these patterns. That is a Phase B+ concern.
+
+### 3. Cost/Performance Optimization
+
+Phase A does not define cost models, performance targets, or optimization strategies.
+
+### 4. Security Policies
+
+While examples may show security patterns, Phase A does not establish comprehensive security policies or threat models.
+
+### 5. Access Control
+
+Phase A does not define who may modify or adopt these patterns beyond the governance structure itself.
+
+---
+
+## Non-Goals
+
+Phase A explicitly does NOT attempt to:
+
+1. **Standardize All Conventions** - Only patterns present in this repository are in scope
+2. **Provide Complete Coverage** - Gaps are acceptable and documented
+3. **Enforce Adoption** - Adoption is voluntary per PROJECT_ADOPTION_CONTRACT.md
+4. **Guarantee Compatibility** - Patterns may require adaptation
+5. **Prevent Divergence** - Forks and modifications are permitted per attachment policy
+
+---
+
+## Scope Boundaries
+
+| Area | In Scope | Out of Scope |
+|------|----------|--------------|
+| Configuration files | ✓ Yes | Runtime values |
+| Pattern templates | ✓ Yes | Actual implementations |
+| Documentation | ✓ Yes | User guides |
+| Governance rules | ✓ Yes | Enforcement mechanisms |
+| GitHub Actions | ✓ Yes (templates) | Actual execution |
+| MCP server configs | ✓ Yes (patterns) | Server implementations |
+| Hook scripts | ✓ Yes | Hook runtime behavior |
+
+---
+
+## Acceptance Criteria
+
+This scope definition is complete when:
+
+1. ✓ All in-scope items are explicitly listed
+2. ✓ All out-of-scope items are explicitly stated
+3. ✓ Explicit exclusions are documented
+4. ✓ Non-goals are stated
+5. ✓ Scope boundaries are clear and unambiguous
+
+---
+
+**Document Status:** COMPLETE
+**Last Updated:** 2026-01-09
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON

--- a/docs/canon/FAIL_CLOSED_AUTOMATION_POLICY.md
+++ b/docs/canon/FAIL_CLOSED_AUTOMATION_POLICY.md
@@ -1,0 +1,459 @@
+# Fail Closed Automation Policy
+
+**Phase:** A (Canonisation)
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON
+**Repository:** claude-code-showcase (Statera-Jason)
+**Status:** Authoritative
+**Version:** 1.0.0
+
+---
+
+## Purpose
+
+This document establishes the fail-closed doctrine for automation in the claude-code-showcase foundation, the "no inference from absence" rule, action gating principles, and prohibited fail-open behaviors.
+
+---
+
+## Fail-Closed Doctrine
+
+### Core Principle
+
+**Automation MUST fail closed, not open.**
+
+When automation encounters:
+- Ambiguity
+- Missing configuration
+- Unexpected state
+- Errors or timeouts
+
+The system MUST:
+- ❌ **STOP** - Halt the action
+- 🚫 **BLOCK** - Prevent potentially harmful operations
+- 📣 **ALERT** - Notify user of the failure
+- ⏸️ **WAIT** - Require explicit human decision
+
+The system MUST NOT:
+- ✗ Guess or infer intent
+- ✗ Proceed with "best effort"
+- ✗ Apply defaults that may be inappropriate
+- ✗ Silently skip or ignore errors
+
+---
+
+## No Inference from Absence
+
+### Rule: Absence ≠ Permission
+
+**If a configuration, setting, or capability is not explicitly present, its behavior is UNDEFINED.**
+
+Automation MUST NOT infer:
+
+| Absent Element | ❌ MUST NOT Assume | ✓ MUST DO Instead |
+|----------------|-------------------|-------------------|
+| Missing skill | "Not needed" | Ask user or document requirement |
+| Missing hook | "Disabled" | Document default behavior |
+| Missing MCP server | "Not authorized" | Block actions requiring that server |
+| Missing environment variable | "Use empty value" | Fail with clear error message |
+| Missing command | "Not supported" | Fail gracefully, suggest alternatives |
+
+### Examples
+
+#### Example 1: Missing Environment Variable
+
+```json
+// .mcp.json
+{
+  "mcpServers": {
+    "jira": {
+      "env": {
+        "JIRA_HOST": "${JIRA_HOST}"
+      }
+    }
+  }
+}
+```
+
+**Fail-Closed Behavior:**
+```
+❌ ERROR: JIRA_HOST environment variable not set
+   Required for MCP server: jira
+   Set with: export JIRA_HOST="https://yourcompany.atlassian.net"
+
+   Blocking JIRA operations until configured.
+```
+
+**Prohibited Fail-Open:**
+```
+⚠️ WARNING: JIRA_HOST not set, using default: https://localhost:8080
+   [INCORRECT - This is dangerous guessing]
+```
+
+#### Example 2: Missing Hook Configuration
+
+**Scenario:** PostToolUse hook for `Edit` tool is not configured.
+
+**Fail-Closed Behavior:**
+```
+No PostToolUse hook configured for Edit tool.
+Edit will proceed without post-processing.
+(This is documented default behavior - acceptable)
+```
+
+**Prohibited Fail-Open:**
+```
+No PostToolUse hook configured, so I'll run Prettier anyway since most projects want that.
+[INCORRECT - This is undocumented inference]
+```
+
+#### Example 3: Unknown Command Argument
+
+**Scenario:** `/ticket PROJ-123 --merge`
+
+Where `--merge` flag is not documented.
+
+**Fail-Closed Behavior:**
+```
+❌ ERROR: Unknown flag: --merge
+   Usage: /ticket <ticket-id>
+
+   Halting execution.
+```
+
+**Prohibited Fail-Open:**
+```
+⚠️ Unknown flag --merge ignored, continuing...
+[INCORRECT - Silently ignoring input is dangerous]
+```
+
+---
+
+## Action Gating Principles
+
+### Principle 1: Explicit Enablement
+
+**High-risk actions MUST require explicit enablement.**
+
+#### High-Risk Actions
+
+- Writing to external systems (JIRA, GitHub issues, Slack)
+- Executing destructive operations (delete, drop, rm -rf)
+- Committing or pushing code
+- Modifying configuration files
+- Installing dependencies
+- Running builds or deployments
+
+#### Gating Mechanism
+
+High-risk actions require:
+
+1. **Explicit configuration:**
+   ```json
+   {
+     "enabledMcpjsonServers": ["jira"],  // Explicit list
+     "allowDestructiveOperations": false  // Default deny
+   }
+   ```
+
+2. **Confirmation prompts:**
+   ```
+   About to commit changes to 15 files.
+   Continue? [y/N]
+   ```
+
+3. **Capability checks:**
+   ```javascript
+   if (!config.mcpServers.jira.enabled) {
+     throw new Error("JIRA MCP server not enabled. Cannot update ticket.");
+   }
+   ```
+
+### Principle 2: Least Privilege
+
+**Grant minimum permissions necessary.**
+
+| Operation | Default Permission | Rationale |
+|-----------|-------------------|-----------|
+| Read files | ✓ Allowed | Low risk, high utility |
+| Write files | ✓ Allowed (with hooks) | Necessary for primary function, protected by hooks |
+| Execute bash | ✓ Allowed (sandboxed) | Necessary, sandboxed by default |
+| Network access | ✓ Allowed | Required for MCP, LSP |
+| MCP server calls | ❌ Denied by default | High risk, require explicit enablement |
+| GitHub Actions | ❌ Disabled by default | Cost and governance concerns |
+
+### Principle 3: Audit Trail
+
+**All high-risk actions MUST be auditable.**
+
+Automation should:
+
+- Log what action was taken
+- Log who/what initiated it
+- Log when it occurred
+- Log the result (success/failure)
+
+Example:
+```
+[2026-01-09T12:34:56Z] MCP:JIRA:UPDATE ticket=PROJ-123 status="In Review" user=claude-code result=success
+```
+
+### Principle 4: Timeout Defaults
+
+**Operations MUST have reasonable timeout defaults.**
+
+| Operation Type | Default Timeout | Rationale |
+|----------------|-----------------|-----------|
+| File operations | No timeout | Local, fast |
+| Bash commands | 7 minutes | Allows builds/tests |
+| Hook execution | 5-90 seconds | Depends on hook type |
+| MCP server calls | 30 seconds | Network operation |
+| Network requests | 30 seconds | Standard HTTP timeout |
+
+**On timeout, MUST fail closed:**
+```
+❌ TIMEOUT: Operation exceeded 30 second limit
+   Operation: MCP:JIRA:GET ticket=PROJ-123
+
+   Halting execution. Check network and retry.
+```
+
+---
+
+## Prohibited Fail-Open Behaviors
+
+The following behaviors are **EXPLICITLY PROHIBITED**:
+
+### 1. Silent Failure
+
+❌ **PROHIBITED:**
+```javascript
+try {
+  updateJiraTicket(id, status);
+} catch (error) {
+  // Silently catch and continue
+}
+```
+
+✓ **REQUIRED:**
+```javascript
+try {
+  updateJiraTicket(id, status);
+} catch (error) {
+  console.error(`Failed to update JIRA ticket ${id}:`, error);
+  throw error; // Propagate failure
+}
+```
+
+### 2. Best-Effort Guessing
+
+❌ **PROHIBITED:**
+```javascript
+if (!config.testCommand) {
+  // Guess based on package.json
+  config.testCommand = hasJest ? "jest" : hasVitest ? "vitest" : "npm test";
+}
+```
+
+✓ **REQUIRED:**
+```javascript
+if (!config.testCommand) {
+  throw new Error("testCommand not configured. Set in CLAUDE.md");
+}
+```
+
+### 3. Undocumented Defaults
+
+❌ **PROHIBITED:**
+```javascript
+// Applying default that's not documented anywhere
+const formatOnSave = config.formatOnSave ?? true; // Hidden default
+```
+
+✓ **REQUIRED:**
+```javascript
+// Default is documented in settings schema
+const formatOnSave = config.formatOnSave ?? false; // Explicit, documented default
+// OR
+if (config.formatOnSave === undefined) {
+  throw new Error("formatOnSave must be explicitly set to true or false");
+}
+```
+
+### 4. Ignoring User Input
+
+❌ **PROHIBITED:**
+```javascript
+// User provided --dry-run flag
+if (args.dryRun) {
+  console.log("Dry run mode not supported, ignoring flag");
+  // Proceed with real operation anyway
+}
+```
+
+✓ **REQUIRED:**
+```javascript
+if (args.dryRun) {
+  console.log("Dry run mode:");
+  console.log("Would execute:", operation);
+  return; // Actually honor the flag
+}
+```
+
+### 5. Automatic Fallbacks Without Consent
+
+❌ **PROHIBITED:**
+```javascript
+// Primary operation failed, automatically try alternative
+try {
+  runPrettier();
+} catch {
+  console.log("Prettier failed, trying Biome instead");
+  runBiome(); // Automatic fallback
+}
+```
+
+✓ **REQUIRED:**
+```javascript
+try {
+  runPrettier();
+} catch (error) {
+  console.error("Prettier failed:", error);
+  console.log("Alternative: Install Biome and configure formatTool: 'biome'");
+  throw error; // Don't automatically fallback
+}
+```
+
+### 6. Proceeding on Dependency Failure
+
+❌ **PROHIBITED:**
+```javascript
+// Hook to run tests after edit
+try {
+  execSync("npm test");
+} catch {
+  console.log("Tests failed, but continuing anyway");
+  // Return success despite test failure
+  return { success: true };
+}
+```
+
+✓ **REQUIRED:**
+```javascript
+try {
+  execSync("npm test");
+  return { success: true, message: "Tests passed" };
+} catch (error) {
+  return { success: false, message: "Tests failed", error };
+  // Caller decides whether to block or warn
+}
+```
+
+### 7. Credential Guessing
+
+❌ **PROHIBITED:**
+```javascript
+// Try common credential locations
+const apiKey = process.env.ANTHROPIC_API_KEY
+  || readFileSync("~/.anthropic/api_key")
+  || readFileSync("/etc/anthropic/api_key")
+  || ""; // Empty fallback
+```
+
+✓ **REQUIRED:**
+```javascript
+const apiKey = process.env.ANTHROPIC_API_KEY;
+if (!apiKey) {
+  throw new Error("ANTHROPIC_API_KEY environment variable required");
+}
+```
+
+---
+
+## Automation Safety Checklist
+
+Before implementing any automation, verify:
+
+- [ ] **Explicit Configuration** - All settings are documented and required
+- [ ] **No Inference** - System does not guess or assume
+- [ ] **Fail Closed** - Errors halt execution
+- [ ] **User Feedback** - Clear error messages guide users
+- [ ] **Audit Trail** - High-risk actions are logged
+- [ ] **Timeout Protection** - Operations have reasonable timeouts
+- [ ] **Least Privilege** - Minimum permissions granted
+- [ ] **Confirmation** - High-risk actions require confirmation
+- [ ] **Reversibility** - Actions can be undone or rolled back
+- [ ] **Documentation** - Behavior is fully documented
+
+---
+
+## Exception: Read-Only Operations
+
+The following operations MAY use documented defaults and need not fail closed:
+
+### Permitted Default Behaviors
+
+1. **File Reading:**
+   - Default: Read entire file if limit not specified
+   - Rationale: Low risk, high utility
+
+2. **Search Operations:**
+   - Default: Search current directory if path not specified
+   - Rationale: Reasonable default, non-destructive
+
+3. **Display Formatting:**
+   - Default: Use terminal width for formatting
+   - Rationale: Cosmetic, no side effects
+
+4. **Log Levels:**
+   - Default: INFO level if not specified
+   - Rationale: Standard practice, non-destructive
+
+### Requirements for Defaults
+
+Even for low-risk operations, defaults MUST be:
+
+1. **Documented** - Stated in configuration reference
+2. **Sensible** - Match user expectations
+3. **Non-destructive** - Cannot cause data loss
+4. **Overridable** - User can explicitly configure
+
+---
+
+## Enforcement
+
+### Phase A Compliance
+
+In Phase A (Canonisation), this policy:
+
+- ✓ Documents principles
+- ✓ Provides examples
+- ✓ States requirements
+- ✗ Does NOT enforce technically (no code execution in Phase A)
+
+### Future Phase Enforcement
+
+In later phases, enforcement may include:
+
+- Automated checks for fail-open patterns
+- Code review requirements
+- Testing for error handling
+- Audit log verification
+
+---
+
+## Acceptance Criteria
+
+This policy is complete when:
+
+1. ✓ Fail-closed doctrine is stated
+2. ✓ "No inference from absence" rule is defined
+3. ✓ Action gating principles are documented
+4. ✓ Prohibited fail-open behaviors are explicit
+5. ✓ Examples of correct and incorrect behavior are provided
+6. ✓ Safety checklist is available
+7. ✓ Exceptions are documented
+
+---
+
+**Document Status:** COMPLETE
+**Last Updated:** 2026-01-09
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON

--- a/docs/canon/INTEGRATIONS_POLICY.md
+++ b/docs/canon/INTEGRATIONS_POLICY.md
@@ -1,0 +1,479 @@
+# Integrations Policy
+
+**Phase:** A (Canonisation)
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON
+**Repository:** claude-code-showcase (Statera-Jason)
+**Status:** Authoritative
+**Version:** 1.0.0
+
+---
+
+## Purpose
+
+This document defines the integration policy for the claude-code-showcase foundation, including MCP server inventory, default integration postures, and explicit non-defaults for GitHub and JIRA.
+
+---
+
+## Integration Posture: Dormant by Default
+
+**Core Principle:** All external integrations are **dormant by default**.
+
+Integrations require:
+1. **Explicit enablement** - User must opt-in
+2. **Credential provision** - User must supply authentication
+3. **Capability verification** - System must confirm integration is functional
+4. **Audit trail** - Usage must be logged
+
+**Why:** Prevents accidental external system modifications, protects credentials, allows cost control.
+
+---
+
+## MCP Server Inventory
+
+### Configured Servers
+
+The following MCP servers are configured in `.mcp.json`:
+
+| Server | Purpose | Status | Credentials Required |
+|--------|---------|--------|---------------------|
+| `jira` | JIRA issue tracking | Dormant | JIRA_HOST, JIRA_EMAIL, JIRA_API_TOKEN |
+| `github` | GitHub API operations | Dormant | GITHUB_TOKEN |
+| `linear` | Linear issue tracking | Dormant | LINEAR_API_KEY |
+| `sentry` | Error monitoring | Dormant | SENTRY_AUTH_TOKEN, SENTRY_ORG |
+| `postgres` | PostgreSQL database | Dormant | DATABASE_URL |
+| `slack` | Slack messaging | Dormant | SLACK_BOT_TOKEN, SLACK_TEAM_ID |
+| `notion` | Notion workspace | Dormant | NOTION_API_KEY |
+| `memory` | Persistent memory | Dormant | None (local storage) |
+
+### Server Status Definitions
+
+| Status | Definition | Enablement Method |
+|--------|------------|-------------------|
+| **Dormant** | Configuration present, server disabled | Explicit enablement + credentials |
+| **Enabled** | Configuration present, explicitly enabled | Set in settings.json + credentials |
+| **Active** | Enabled and successfully connected | Runtime verification |
+| **Failed** | Enabled but connection failed | Check credentials and network |
+
+### Enablement Methods
+
+#### Method 1: Enable All Project MCP Servers
+
+```json
+// .claude/settings.json
+{
+  "enableAllProjectMcpServers": true
+}
+```
+
+**Effect:** Enables all servers in `.mcp.json` (credentials still required)
+
+**Risk:** High - Enables all integrations without selective control
+
+**Recommended For:** Development environments, trusted projects
+
+---
+
+#### Method 2: Enable Specific Servers (Recommended)
+
+```json
+// .claude/settings.json
+{
+  "enabledMcpjsonServers": ["jira", "github"]
+}
+```
+
+**Effect:** Enables only specified servers
+
+**Risk:** Medium - Controlled enablement
+
+**Recommended For:** Production environments, selective integration
+
+---
+
+#### Method 3: Disable All (Default)
+
+```json
+// .claude/settings.json (or omit MCP configuration)
+{
+  // No MCP enablement
+}
+```
+
+**Effect:** All MCP servers remain dormant
+
+**Risk:** None - No external access
+
+**Recommended For:** Initial setup, security-first environments
+
+---
+
+## Integration-Specific Policies
+
+### JIRA Integration
+
+**Status:** Dormant by Default
+
+**Configuration:**
+```json
+{
+  "mcpServers": {
+    "jira": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-jira"],
+      "env": {
+        "JIRA_HOST": "${JIRA_HOST}",
+        "JIRA_EMAIL": "${JIRA_EMAIL}",
+        "JIRA_API_TOKEN": "${JIRA_API_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+**Capabilities When Enabled:**
+- Read issue details, comments, attachments
+- Update issue status, assignee, priority
+- Add comments to issues
+- Create new issues
+- Search issues with JQL
+- Link issues, create subtasks
+
+**Authorization Requirements:**
+- JIRA API token with appropriate project permissions
+- Email address associated with JIRA account
+- Host URL for JIRA instance
+
+**Risks:**
+- **HIGH:** Can modify production tickets
+- **MEDIUM:** Can create spam issues if misconfigured
+- **LOW:** Can read sensitive ticket data
+
+**Posture: Retained but Dormant**
+
+JIRA is **NOT** the primary workflow for this foundation. GitHub Issues and GitHub Projects are the intended defaults.
+
+However, JIRA integration is **retained in canon** because:
+1. Many organizations use JIRA as system of record
+2. Provides reference for enterprise issue tracking
+3. Demonstrates MCP server patterns
+4. Supports `/ticket` command workflow
+
+**Default Workflow Priority:**
+1. GitHub Issues (intended default, implementation deferred to Phase B)
+2. GitHub Projects (intended default, implementation deferred to Phase B)
+3. JIRA (available but dormant)
+4. Linear (available but dormant)
+
+**Adoption Guidance:**
+- Projects using JIRA: Enable `jira` MCP server explicitly
+- Projects using GitHub only: Leave JIRA dormant, remove from `.mcp.json` if desired
+- Projects using Linear: Enable `linear` MCP server instead
+
+---
+
+### GitHub Integration
+
+**Status:** Dormant by Default
+
+**Configuration:**
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-github"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+**Capabilities When Enabled:**
+- Read repository information
+- List and read issues
+- Create and update issues
+- Manage pull requests
+- Create releases
+- Manage labels, milestones
+
+**Authorization Requirements:**
+- GitHub personal access token or app token
+- Token scopes: `repo`, `issues`, `pull_requests` (minimum)
+
+**Risks:**
+- **HIGH:** Can create/modify issues and PRs
+- **MEDIUM:** Can manage repository settings (if token permits)
+- **LOW:** Can read repository data
+
+**Intended Default (Implementation Deferred):**
+
+GitHub is the **intended primary workflow** for this foundation. However:
+
+- Phase A: Configuration present but dormant
+- Phase B+: Implementation of GitHub-first workflow
+- Requires: Explicit user request to enable
+
+**Why Deferred:**
+- Phase A is documentation only, not implementation
+- GitHub workflow requires runtime behavior definition
+- Cost and governance gates not yet defined
+
+**Adoption Guidance:**
+- Enable `github` MCP server for full GitHub integration
+- Use `gh` CLI as alternative for some operations
+- GitHub Actions workflows are separate (see CAP-008)
+
+---
+
+### Other Integrations
+
+#### Linear
+
+**Status:** Dormant by Default
+
+**Use Case:** Alternative to JIRA for modern issue tracking
+
+**Enablement:** Set `enabledMcpjsonServers: ["linear"]` and provide `LINEAR_API_KEY`
+
+---
+
+#### Slack
+
+**Status:** Dormant by Default
+
+**Use Case:** Notifications, status updates, team communication
+
+**Risks:** HIGH - Can send messages to channels, potential for spam
+
+**Enablement:** Requires bot token with explicit channel permissions
+
+---
+
+#### Sentry
+
+**Status:** Dormant by Default
+
+**Use Case:** Error monitoring, reading error reports, creating issue links
+
+**Risks:** LOW - Primarily read-only, can link errors to issues
+
+---
+
+#### Postgres
+
+**Status:** Dormant by Default
+
+**Use Case:** Database query for debugging, schema inspection
+
+**Risks:** VERY HIGH - Direct database access, potential for data loss
+
+**Recommendation:** Only enable in isolated development environments, never production
+
+---
+
+#### Notion
+
+**Status:** Dormant by Default
+
+**Use Case:** Documentation reading/writing, knowledge base integration
+
+**Risks:** MEDIUM - Can modify documentation
+
+---
+
+#### Memory
+
+**Status:** Dormant by Default
+
+**Use Case:** Persistent storage for context across sessions
+
+**Risks:** LOW - Local storage only
+
+---
+
+## Integration Security Requirements
+
+### Credential Management
+
+**MUST:**
+- ✓ Store credentials in environment variables
+- ✓ Use `.env` files (gitignored) or system environment
+- ✓ Document required credential scopes/permissions
+- ✓ Rotate credentials periodically
+
+**MUST NOT:**
+- ✗ Commit credentials to version control
+- ✗ Store credentials in `.mcp.json` directly
+- ✗ Share credentials across environments (dev/staging/prod)
+- ✗ Use overly permissive tokens (principle of least privilege)
+
+### Example: Secure Credential Setup
+
+```bash
+# .env (gitignored)
+JIRA_HOST=https://yourcompany.atlassian.net
+JIRA_EMAIL=bot@yourcompany.com
+JIRA_API_TOKEN=ATATT3xFfGF0...
+
+GITHUB_TOKEN=ghp_abc123...
+
+# Load in shell profile
+export $(cat .env | xargs)
+
+# Or use direnv
+# echo 'dotenv' > .envrc
+# direnv allow
+```
+
+### Token Scopes
+
+Minimum required scopes for each integration:
+
+| Integration | Minimum Scopes | Why |
+|-------------|---------------|-----|
+| JIRA | Read/Write issues | Ticket workflow |
+| GitHub | `repo`, `issues` | Issue management, PR operations |
+| Linear | Read/Write issues | Issue tracking |
+| Slack | `chat:write`, `channels:read` | Send messages to authorized channels |
+| Sentry | `project:read`, `event:read` | Read error data |
+| Postgres | `CONNECT`, `SELECT` (read-only recommended) | Query execution |
+| Notion | Read/Write pages | Documentation access |
+
+---
+
+## GitHub Actions Integration
+
+**Status:** Disabled by Default
+
+**Location:** `.github/workflows/`
+
+**Workflows:**
+- `pr-claude-code-review.yml` - Automated PR reviews
+- `scheduled-claude-code-docs-sync.yml` - Monthly documentation sync
+- `scheduled-claude-code-quality.yml` - Weekly code quality
+- `scheduled-claude-code-dependency-audit.yml` - Biweekly dependency updates
+
+**Why Disabled by Default:**
+
+1. **Cost Concerns:**
+   - Anthropic API usage: ~$10-50/month estimated
+   - GitHub Actions minutes: Included in most plans
+   - Unpredictable costs based on PR volume
+
+2. **Governance Concerns:**
+   - Automated commits require review
+   - PR review quality needs validation
+   - Scheduled jobs may conflict with team workflows
+
+3. **Configuration Required:**
+   - `ANTHROPIC_API_KEY` secret must be set
+   - Workflows may need customization for project
+   - Branch protection rules may need adjustment
+
+**Enablement Requirements:**
+
+1. Review each workflow for project fit
+2. Set `ANTHROPIC_API_KEY` in repository secrets
+3. Test on non-production branches first
+4. Monitor costs and adjust schedules
+5. Commit workflows to `.github/workflows/` to enable
+
+**Adoption Guidance:**
+- Start with `pr-claude-code-review.yml` only
+- Monitor costs for 1 month before enabling scheduled workflows
+- Disable or adjust schedules if costs exceed budget
+
+---
+
+## Integration Testing
+
+### Verification Checklist
+
+Before relying on an integration:
+
+- [ ] Credentials configured correctly
+- [ ] MCP server enabled in settings.json
+- [ ] Server connects successfully (check logs)
+- [ ] Test operations in development environment
+- [ ] Audit trail configured (if applicable)
+- [ ] Error handling tested (network failure, auth failure)
+- [ ] Cost implications understood
+
+### Test Commands
+
+```bash
+# Test JIRA connection
+claude "Using JIRA MCP, read ticket PROJ-123"
+
+# Test GitHub connection
+claude "Using GitHub MCP, list issues in this repo"
+
+# Verify MCP server status
+# (Check Claude Code output for MCP connection logs)
+```
+
+---
+
+## Integration Audit Trail
+
+### Required Logging
+
+For all integrations, log:
+- Action taken (read, write, create, update, delete)
+- Resource affected (ticket ID, issue number, etc.)
+- Timestamp
+- Result (success, failure, error)
+
+### Example Log Format
+
+```
+[2026-01-09T12:34:56Z] MCP:JIRA:UPDATE ticket=PROJ-123 field=status value="In Review" result=success
+[2026-01-09T12:35:10Z] MCP:GITHUB:CREATE_ISSUE repo=owner/repo title="Bug: ..." result=success
+[2026-01-09T12:35:15Z] MCP:SLACK:SEND_MESSAGE channel=#engineering message="PR ready" result=success
+```
+
+---
+
+## Explicit Non-Defaults
+
+### GitHub Issues as Primary Workflow
+
+**Status:** Intended default, implementation deferred
+
+**Phase A:** Configuration and policy only
+**Phase B+:** Runtime implementation when explicitly requested
+
+**Reason for Deferral:**
+- GitHub integration patterns need refinement
+- Cost and governance gates need definition
+- User workflow research required
+
+### JIRA as Secondary Option
+
+**Status:** Retained but not primary
+
+**Reason:** Enterprise requirement support, but GitHub Issues preferred for open-source and GitHub-native workflows
+
+---
+
+## Acceptance Criteria
+
+This policy is complete when:
+
+1. ✓ MCP server inventory is complete
+2. ✓ Default posture (dormant) is stated
+3. ✓ Enablement methods are documented
+4. ✓ Integration-specific policies are defined
+5. ✓ Security requirements are explicit
+6. ✓ GitHub Actions status is documented
+7. ✓ Explicit non-defaults are stated (GitHub as intended default, JIRA retained but dormant)
+
+---
+
+**Document Status:** COMPLETE
+**Last Updated:** 2026-01-09
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON

--- a/docs/canon/PHASE_MAP.md
+++ b/docs/canon/PHASE_MAP.md
@@ -1,0 +1,465 @@
+# Phase Map
+
+**Phase:** A (Canonisation)
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON
+**Repository:** claude-code-showcase (Statera-Jason)
+**Status:** Authoritative
+**Version:** 1.0.0
+
+---
+
+## Purpose
+
+This document defines the phase structure for claude-code-showcase foundation governance, authority transitions between phases, and the explicit rule that Claude prompts may not be generated unless explicitly requested.
+
+---
+
+## Phase Structure
+
+The claude-code-showcase foundation follows a five-phase governance model:
+
+```
+Phase A → Phase B → Phase C → Phase D → Phase E
+(Canon)   (Impl.)   (Integ.)  (Oper.)   (Evol.)
+```
+
+Each phase has distinct scope, authority, and constraints.
+
+---
+
+## Phase A: Canonisation (Current)
+
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON
+
+**Status:** ACTIVE
+
+**Scope:** Documentation, specification, governance structure
+
+### Objectives
+
+1. ✓ Define scope boundaries (CLAUDE_FOUNDATION_SCOPE.md)
+2. ✓ Enumerate capabilities (CLAUDE_FOUNDATION_CAPABILITIES_REGISTER.md)
+3. ✓ Establish adoption contracts (PROJECT_ADOPTION_CONTRACT.md)
+4. ✓ Define attachment patterns (ATTACHMENT_PACKAGING_STRATEGY.md)
+5. ✓ Document automation policies (FAIL_CLOSED_AUTOMATION_POLICY.md)
+6. ✓ Specify integration posture (INTEGRATIONS_POLICY.md)
+7. ✓ Map phases and transitions (PHASE_MAP.md)
+
+### Deliverables
+
+All Phase A deliverables are located in `docs/canon/`:
+
+| Document | Status | Purpose |
+|----------|--------|---------|
+| CLAUDE_FOUNDATION_SCOPE.md | ✓ Complete | Defines what is/isn't in scope |
+| CLAUDE_FOUNDATION_CAPABILITIES_REGISTER.md | ✓ Complete | Enumerates all capabilities, dependencies, risks |
+| PROJECT_ADOPTION_CONTRACT.md | ✓ Complete | Must/should/must-not for adopters |
+| ATTACHMENT_PACKAGING_STRATEGY.md | ✓ Complete | How to attach foundation to projects |
+| FAIL_CLOSED_AUTOMATION_POLICY.md | ✓ Complete | Fail-closed doctrine and safety |
+| INTEGRATIONS_POLICY.md | ✓ Complete | MCP servers, GitHub Actions, defaults |
+| PHASE_MAP.md | ✓ Complete | Phase structure and transitions |
+
+### Constraints
+
+Phase A **MUST NOT**:
+
+- ❌ Generate Claude Code prompts
+- ❌ Generate Claude Web prompts
+- ❌ Define runtime behavior
+- ❌ Implement execution logic
+- ❌ Create operational hooks (only document patterns)
+- ❌ Enable integrations (only document configuration)
+
+Phase A **MUST**:
+
+- ✓ Document structure and patterns
+- ✓ Define governance rules
+- ✓ Enumerate capabilities
+- ✓ Specify constraints
+- ✓ Establish acceptance criteria
+
+### Completion Criteria
+
+Phase A is complete when:
+
+- [x] All seven canon documents are written
+- [x] All documents have clear sections
+- [x] All decisions are explicit
+- [x] All acceptance criteria are met
+- [x] All documents are committed to version control
+
+### Exit Condition
+
+Phase A concludes when:
+
+1. All deliverables are complete
+2. Phase A authority approves completion
+3. Repository is in clean state
+4. No runtime behavior has been implemented
+
+**Phase A STOPS here. Do not proceed to Phase B.**
+
+---
+
+## Phase B: Implementation (Future)
+
+**Authority:** GC_CLAUDE_FOUNDATION-B_IMPL (not yet assigned)
+
+**Status:** NOT STARTED
+
+**Prerequisite:** Phase A completion
+
+**Scope:** Runtime behavior, execution logic, Claude prompt generation
+
+### Objectives (Proposed)
+
+1. Define Claude Code behavior for foundation patterns
+2. Implement skill activation logic
+3. Define hook execution semantics
+4. Specify command runtime behavior
+5. Create agent execution patterns
+6. Generate Claude prompts (when explicitly requested)
+
+### Constraints
+
+Phase B **MAY**:
+
+- ✓ Generate Claude prompts (only when explicitly requested)
+- ✓ Define runtime behavior
+- ✓ Implement execution logic
+- ✓ Create operational hooks
+- ✓ Define Claude decision-making patterns
+
+Phase B **MUST NOT**:
+
+- ❌ Generate prompts without explicit request
+- ❌ Modify Phase A canon without governance approval
+- ❌ Enable integrations without user consent
+- ❌ Violate fail-closed doctrine
+
+### Deliverables (Proposed)
+
+- Runtime behavior specifications
+- Skill activation logic
+- Hook execution semantics
+- Command runtime definitions
+- Agent execution patterns
+- Claude prompt templates (when requested)
+
+### Entry Condition
+
+Phase B may begin when:
+
+1. Phase A is complete
+2. User explicitly requests Phase B work
+3. Authority is assigned for Phase B
+4. Clear implementation scope is defined
+
+**Phase B has NOT been requested. Do not proceed.**
+
+---
+
+## Phase C: Integration (Future)
+
+**Authority:** GC_CLAUDE_FOUNDATION-C_INTEG (not yet assigned)
+
+**Status:** NOT STARTED
+
+**Prerequisite:** Phase B completion
+
+**Scope:** External system integration, MCP server operationalization, GitHub Actions deployment
+
+### Objectives (Proposed)
+
+1. Operationalize MCP servers
+2. Deploy GitHub Actions workflows
+3. Integrate with JIRA/Linear/GitHub
+4. Test integration workflows
+5. Document integration patterns
+
+### Constraints
+
+Phase C **MAY**:
+
+- ✓ Enable MCP servers (with consent)
+- ✓ Deploy GitHub Actions (with approval)
+- ✓ Create external system connections
+- ✓ Test integrations in live environments
+
+Phase C **MUST NOT**:
+
+- ❌ Enable integrations without explicit consent
+- ❌ Store credentials in version control
+- ❌ Violate integration security requirements
+- ❌ Proceed without cost approval
+
+### Entry Condition
+
+Phase C may begin when:
+
+1. Phase B is complete
+2. User explicitly requests integration work
+3. Cost and governance gates are approved
+4. Credentials are securely provided
+
+**Phase C has NOT been requested. Do not proceed.**
+
+---
+
+## Phase D: Operations (Future)
+
+**Authority:** GC_CLAUDE_FOUNDATION-D_OPER (not yet assigned)
+
+**Status:** NOT STARTED
+
+**Prerequisite:** Phase C completion
+
+**Scope:** Operational monitoring, cost tracking, performance optimization, incident response
+
+### Objectives (Proposed)
+
+1. Monitor integration usage and costs
+2. Track performance metrics
+3. Respond to operational issues
+4. Optimize for cost and latency
+5. Maintain audit trails
+
+### Entry Condition
+
+Phase D may begin when:
+
+1. Phase C is complete
+2. System is in production operation
+3. Monitoring and alerting are required
+
+**Phase D has NOT been requested. Do not proceed.**
+
+---
+
+## Phase E: Evolution (Future)
+
+**Authority:** GC_CLAUDE_FOUNDATION-E_EVOL (not yet assigned)
+
+**Status:** NOT STARTED
+
+**Prerequisite:** Phase D completion
+
+**Scope:** Long-term evolution, pattern refinement, community feedback integration, major version updates
+
+### Objectives (Proposed)
+
+1. Gather community feedback
+2. Refine patterns based on real-world usage
+3. Plan major version updates
+4. Deprecate obsolete patterns
+5. Integrate improvements from adopters
+
+### Entry Condition
+
+Phase E is ongoing after Phase D and continues throughout foundation lifecycle.
+
+**Phase E has NOT been requested. Do not proceed.**
+
+---
+
+## Authority Transitions
+
+### Phase A → Phase B
+
+**Trigger:** User explicitly requests implementation work
+
+**Requirements:**
+- Phase A completion verified
+- New authority assigned (GC_CLAUDE_FOUNDATION-B_IMPL)
+- Implementation scope defined
+- User approval obtained
+
+**Process:**
+1. Verify Phase A deliverables complete
+2. User requests: "Begin Phase B implementation"
+3. Assign Phase B authority
+4. Define implementation scope
+5. Proceed with Phase B objectives
+
+### Phase B → Phase C
+
+**Trigger:** User explicitly requests integration work
+
+**Requirements:**
+- Phase B completion verified
+- Integration targets identified
+- Cost and governance approval obtained
+- Credentials securely provided
+
+### Phase C → Phase D
+
+**Trigger:** System enters production operation
+
+**Requirements:**
+- Phase C completion verified
+- Production deployment approved
+- Monitoring and alerting configured
+
+### Phase D → Phase E
+
+**Trigger:** Ongoing evolution needs identified
+
+**Requirements:**
+- Phase D operational maturity
+- Feedback collection mechanisms
+- Version planning process
+
+---
+
+## Explicit Rules
+
+### Rule 1: No Claude Prompts Unless Explicitly Requested
+
+**Phase A PROHIBITION:**
+
+Claude Code prompts, Claude Web prompts, or any executable AI instructions targeting Claude models **MUST NOT** be generated in Phase A.
+
+**Rationale:**
+- Phase A is documentation and governance only
+- Prompt generation is runtime behavior (Phase B)
+- Premature prompt generation violates phase boundaries
+
+**Exception:**
+- Phase B or later phases MAY generate prompts when **user explicitly requests** them
+- Example explicit request: "Generate a Claude prompt for skill activation"
+
+**Violation Examples:**
+```
+❌ "Let me create a prompt for the code-reviewer agent"
+❌ "Here's a Claude prompt to use with this skill"
+❌ "I'll generate instructions for Claude to follow"
+```
+
+**Compliant Examples:**
+```
+✓ "The code-reviewer agent is documented in .claude/agents/code-reviewer.md"
+✓ "Skill content is defined in SKILL.md files"
+✓ "Prompt generation is deferred to Phase B when explicitly requested"
+```
+
+### Rule 2: Phase Boundaries Are Strict
+
+Each phase has distinct scope. **DO NOT** perform work from future phases without:
+
+1. Completing current phase
+2. Obtaining explicit user request
+3. Assigning appropriate authority
+4. Verifying prerequisites
+
+### Rule 3: Backwards Compatibility
+
+Later phases **MUST NOT** violate Phase A canon without:
+
+1. Major version bump
+2. Clear documentation of breaking changes
+3. Migration guide
+4. Deprecation period
+
+### Rule 4: Fail-Closed at Phase Boundaries
+
+When uncertain whether work belongs in current phase:
+
+- **STOP**
+- **ASK** user for clarification
+- **DOCUMENT** ambiguity
+- **WAIT** for explicit direction
+
+**DO NOT** infer that work is appropriate for current phase.
+
+---
+
+## Branching Requirements (Recorded Only)
+
+**Note:** This is a **recorded requirement**, not an executable instruction.
+
+### Future Claude Execution Branches
+
+When Claude Code operates in execution mode (Phase B+), all branches **MUST**:
+
+1. **Branch from:** `Project420_Claude`
+2. **Naming convention:** Include phase identifier in branch name
+3. **Examples:**
+   - `Project420_Claude/phase-b-impl-skills`
+   - `Project420_Claude/phase-c-jira-integration`
+   - `Project420_Claude/phase-d-monitoring`
+
+### Current Branch
+
+Current work (Phase A canonisation) is on:
+- Branch: `claude/foundation-phase-a-canon-0xzBZ`
+
+This branch naming follows the current session convention.
+
+### Phase A Action
+
+Phase A records this requirement but **does NOT**:
+- Create the `Project420_Claude` branch
+- Enforce branch naming
+- Perform git operations beyond documentation commits
+
+**Implementation:** Deferred to Phase B+ when execution begins.
+
+---
+
+## Phase Progression Summary
+
+| Phase | Status | Authority | Work Type | Prompt Generation |
+|-------|--------|-----------|-----------|-------------------|
+| **A: Canonisation** | ✓ Active | GC_CLAUDE_FOUNDATION-A_CANON | Documentation | ❌ Prohibited |
+| **B: Implementation** | Not Started | Unassigned | Runtime behavior | ✓ When requested |
+| **C: Integration** | Not Started | Unassigned | External systems | ✓ When requested |
+| **D: Operations** | Not Started | Unassigned | Monitoring | ✓ When requested |
+| **E: Evolution** | Not Started | Unassigned | Refinement | ✓ When requested |
+
+---
+
+## Acceptance Criteria
+
+This phase map is complete when:
+
+1. ✓ All five phases are defined
+2. ✓ Phase A objectives and deliverables are complete
+3. ✓ Future phase objectives are proposed (not committed)
+4. ✓ Authority transitions are documented
+5. ✓ Explicit rules are stated (no prompts unless requested)
+6. ✓ Branching requirements are recorded
+7. ✓ Phase boundaries are clear
+
+---
+
+## Phase A Completion Statement
+
+### Status: COMPLETE
+
+All Phase A deliverables have been created:
+
+1. ✓ CLAUDE_FOUNDATION_SCOPE.md
+2. ✓ CLAUDE_FOUNDATION_CAPABILITIES_REGISTER.md
+3. ✓ PROJECT_ADOPTION_CONTRACT.md
+4. ✓ ATTACHMENT_PACKAGING_STRATEGY.md
+5. ✓ FAIL_CLOSED_AUTOMATION_POLICY.md
+6. ✓ INTEGRATIONS_POLICY.md
+7. ✓ PHASE_MAP.md
+
+### Next Steps
+
+**STOP HERE.**
+
+Phase A is complete. Do not proceed to Phase B or generate Claude prompts.
+
+To continue:
+1. User must explicitly request Phase B work
+2. Authority must be assigned for Phase B
+3. Implementation scope must be defined
+
+---
+
+**Document Status:** COMPLETE
+**Last Updated:** 2026-01-09
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON
+**Phase A Status:** ✓ COMPLETE - STOP

--- a/docs/canon/PROJECT_ADOPTION_CONTRACT.md
+++ b/docs/canon/PROJECT_ADOPTION_CONTRACT.md
@@ -1,0 +1,391 @@
+# Project Adoption Contract
+
+**Phase:** A (Canonisation)
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON
+**Repository:** claude-code-showcase (Statera-Jason)
+**Status:** Authoritative
+**Version:** 1.0.0
+
+---
+
+## Purpose
+
+This contract defines the expectations, requirements, and constraints for projects that adopt the claude-code-showcase foundation. It establishes what adopting projects must, should, and must not do, as well as detachment expectations.
+
+---
+
+## Adoption Model
+
+The claude-code-showcase repository operates as an **attachable foundation**, not a hard dependency. Projects may:
+
+- Adopt all or part of this foundation
+- Customize and extend capabilities
+- Diverge from patterns as needed
+- Detach without destabilization
+
+This is **not** a framework. It is a **reference implementation and governance layer**.
+
+---
+
+## Must Do (Required)
+
+Projects that adopt this foundation **MUST**:
+
+### 1. Acknowledge Source
+
+Adopting projects must retain attribution in an appropriate location:
+
+```markdown
+<!-- In README.md or CLAUDE.md -->
+Claude Code configuration adapted from:
+https://github.com/Statera-Jason/claude-code-showcase
+```
+
+**Why:** Maintains provenance and allows others to find the source.
+
+### 2. Review Security Implications
+
+Before adopting CAP-007 (MCP Server Integration), projects must:
+
+- Review credential exposure risks
+- Ensure environment variables are not committed
+- Understand API access granted to Claude Code
+- Document which MCP servers are enabled
+
+**Why:** MCP servers grant Claude Code access to external systems. This must be intentional.
+
+### 3. Test Hooks Before Production Use
+
+Before relying on CAP-002 (Hook Configuration), projects must:
+
+- Test hooks in development environment
+- Verify shell compatibility (bash vs sh)
+- Confirm timeout values are appropriate
+- Test failure scenarios (blocked actions, timeouts)
+
+**Why:** Hook failures can block workflows or cause unexpected behavior.
+
+### 4. Customize for Project Context
+
+Projects must customize:
+
+- `CLAUDE.md` - Replace with project-specific information
+- `.claude/skills/` - Adapt or remove skills that don't apply
+- `.claude/commands/` - Modify commands for project workflows
+- `.claude/agents/` - Update checklists for project standards
+
+**Why:** Template content is illustrative only. Direct usage will cause confusion.
+
+### 5. Version Control Configuration
+
+Projects must commit to version control:
+
+- `.claude/settings.json` (hook configuration)
+- `.claude/skills/` (team-shared skills)
+- `.claude/agents/` (team-shared agents)
+- `.claude/commands/` (team-shared commands)
+- `CLAUDE.md` (project memory)
+- `.mcp.json` (MCP server configuration - WITHOUT credentials)
+
+**Why:** Configuration is a team asset that should be versioned and reviewed.
+
+### 6. Exclude Secrets from Version Control
+
+Projects must ensure the following are **never** committed:
+
+- `.claude/settings.local.json` (personal overrides)
+- `CLAUDE.local.md` (personal notes)
+- Environment files with credentials (`.env`, etc.)
+- API keys or tokens in any configuration
+
+**Why:** Prevents credential exposure.
+
+---
+
+## Should Do (Recommended)
+
+Projects that adopt this foundation **SHOULD**:
+
+### 1. Start Incrementally
+
+Adopt capabilities in phases:
+
+1. Phase 1: `CLAUDE.md` only
+2. Phase 2: Add 1-2 skills for common patterns
+3. Phase 3: Add hooks for automation
+4. Phase 4: Add commands for workflows
+5. Phase 5: Consider MCP servers and GitHub Actions
+
+**Why:** Reduces complexity and allows learning curve.
+
+### 2. Document Local Customizations
+
+When diverging from foundation patterns, document why:
+
+```markdown
+<!-- In .claude/README.md or similar -->
+## Deviations from claude-code-showcase
+
+- Hooks: Modified to use POSIX sh instead of bash (DEF-001 workaround)
+- Skills: Removed graphql-schema (not applicable)
+- MCP: Added custom server for internal API
+```
+
+**Why:** Helps future maintainers understand decisions.
+
+### 3. Contribute Improvements Back
+
+If you fix defects or improve patterns, consider:
+
+- Opening issues in claude-code-showcase
+- Submitting PRs with improvements
+- Sharing knowledge with community
+
+**Why:** Benefits all adopters and improves foundation.
+
+### 4. Monitor Costs
+
+If adopting CAP-008 (GitHub Actions):
+
+- Track Anthropic API usage
+- Monitor GitHub Actions minutes
+- Review cost reports monthly
+- Adjust workflow frequency if needed
+
+**Why:** Prevents unexpected costs.
+
+### 5. Review and Update Periodically
+
+Every quarter, review:
+
+- Are skills still accurate?
+- Do hooks still work correctly?
+- Are commands still relevant?
+- Can any automation be improved?
+
+**Why:** Prevents configuration drift and staleness.
+
+---
+
+## Must Not Do (Prohibited)
+
+Projects that adopt this foundation **MUST NOT**:
+
+### 1. Assume Patterns Are Universal
+
+Do not assume:
+
+- All skills apply to your project
+- Hook timeouts are optimal for your environment
+- Command workflows match your processes
+- MCP server configurations are complete
+
+**Why:** This is a reference implementation, not a universal solution.
+
+### 2. Enable All Capabilities Without Review
+
+Do not blindly enable:
+
+- All MCP servers
+- All GitHub Actions workflows
+- All hooks without testing
+- All skills without customization
+
+**Why:** Each capability has risks and requirements that must be evaluated.
+
+### 3. Store Credentials in Configuration
+
+Do not commit:
+
+- API keys in `.mcp.json`
+- Tokens in `.claude/settings.json`
+- Passwords anywhere in `.claude/`
+
+**Why:** Credentials must be environment-specific and secret.
+
+### 4. Depend on Defect Behavior
+
+Do not rely on:
+
+- DEF-001 (bash/sh mismatch) behavior
+- Undocumented features
+- Implementation details not in canon
+
+**Why:** Defects may be fixed, causing unexpected breakage.
+
+### 5. Block Detachment
+
+Do not create dependencies that prevent:
+
+- Removing `.claude/` directory
+- Disabling specific capabilities
+- Reverting to vanilla Claude Code
+
+**Why:** Maintains attachment-first posture. Projects must be able to detach.
+
+---
+
+## Detachment Expectations
+
+Projects may detach from this foundation at any time by:
+
+1. **Removing Configuration:**
+   ```bash
+   rm -rf .claude/
+   rm CLAUDE.md
+   rm .mcp.json
+   ```
+
+2. **Keeping Customizations:**
+   Projects may retain customized skills, agents, or commands even after detaching from the foundation.
+
+3. **Minimal Impact:**
+   Detachment should not break core project functionality. If it does, the project has become over-dependent.
+
+### Detachment Checklist
+
+- [ ] Remove `.claude/` directory or specific capability files
+- [ ] Remove `CLAUDE.md` if desired
+- [ ] Remove `.mcp.json` if desired
+- [ ] Remove GitHub Actions workflows if present
+- [ ] Verify project still functions without Claude Code configuration
+- [ ] Update documentation to reflect detachment
+
+---
+
+## Adoption Levels
+
+Projects may adopt at different levels:
+
+### Level 1: Documentation Only
+
+Adopt only:
+- `CLAUDE.md` pattern
+
+**Effort:** Low
+**Risk:** None
+**Benefit:** Basic project memory
+
+### Level 2: Skills and Documentation
+
+Adopt:
+- `CLAUDE.md`
+- Selected `.claude/skills/`
+
+**Effort:** Low-Medium
+**Risk:** Low
+**Benefit:** Consistent code patterns
+
+### Level 3: Automation with Hooks
+
+Adopt:
+- `CLAUDE.md`
+- `.claude/skills/`
+- `.claude/settings.json` (hooks)
+
+**Effort:** Medium
+**Risk:** Medium (DEF-001, shell compatibility)
+**Benefit:** Automated formatting, testing, type-checking
+
+### Level 4: Workflows and Commands
+
+Adopt:
+- Level 3 +
+- `.claude/commands/`
+- `.claude/agents/`
+
+**Effort:** Medium-High
+**Risk:** Medium
+**Benefit:** Streamlined workflows, code review
+
+### Level 5: Full Integration
+
+Adopt:
+- Level 4 +
+- `.mcp.json` (MCP servers)
+- `.github/workflows/` (GitHub Actions)
+
+**Effort:** High
+**Risk:** High (costs, credentials, governance)
+**Benefit:** Full automation, external integrations
+
+---
+
+## Support and Maintenance
+
+### What This Foundation Provides
+
+- ✓ Reference implementations
+- ✓ Documentation of patterns
+- ✓ Known defect tracking
+- ✓ Governance structure
+
+### What This Foundation Does NOT Provide
+
+- ✗ Ongoing support for adopting projects
+- ✗ Compatibility guarantees across updates
+- ✗ Testing of configurations in all environments
+- ✗ Resolution of project-specific issues
+
+### Adopter Responsibilities
+
+Adopting projects are responsible for:
+
+- Testing in their environment
+- Maintaining their customizations
+- Monitoring their costs and performance
+- Updating as their needs evolve
+- Seeking help through appropriate channels (not foundation maintainers)
+
+---
+
+## Compatibility and Updates
+
+### Versioning
+
+The foundation uses semantic versioning for canon documents:
+
+- **Major (X.0.0):** Breaking changes to contracts or expectations
+- **Minor (0.X.0):** New capabilities or significant updates
+- **Patch (0.0.X):** Bug fixes, clarifications, documentation
+
+Current Version: **1.0.0**
+
+### Update Policy
+
+- Adopting projects are NOT required to update
+- Updates are pull-based, not push-based
+- Breaking changes will be clearly documented
+- Legacy patterns may be deprecated but remain documented
+
+### Compatibility Promise
+
+The foundation commits to:
+
+- Not removing capabilities without major version bump
+- Documenting all breaking changes
+- Maintaining historical documentation
+
+The foundation does NOT promise:
+
+- Backwards compatibility for all customizations
+- Support for old versions
+- Migration guides for all changes
+
+---
+
+## Acceptance Criteria
+
+This contract is complete when:
+
+1. ✓ Must/Should/Must Not requirements are explicit
+2. ✓ Detachment expectations are clear
+3. ✓ Adoption levels are defined
+4. ✓ Support boundaries are stated
+5. ✓ Versioning policy is established
+
+---
+
+**Document Status:** COMPLETE
+**Last Updated:** 2026-01-09
+**Authority:** GC_CLAUDE_FOUNDATION-A_CANON


### PR DESCRIPTION
Add complete Phase A canonisation layer defining governance, scope, capabilities, adoption contracts, and policies for claude-code-showcase foundation.

Documents created:
- CLAUDE_FOUNDATION_SCOPE.md: In-scope vs out-of-scope boundaries
- CLAUDE_FOUNDATION_CAPABILITIES_REGISTER.md: All capabilities with dependencies, risks, and known defects (DEF-001: bash/sh mismatch)
- PROJECT_ADOPTION_CONTRACT.md: Must/should/must-not for adopters
- ATTACHMENT_PACKAGING_STRATEGY.md: Permitted attachment patterns
- FAIL_CLOSED_AUTOMATION_POLICY.md: Fail-closed doctrine and safety
- INTEGRATIONS_POLICY.md: MCP servers, GitHub Actions, integration posture
- PHASE_MAP.md: Phase structure, authority transitions, and explicit rule that Claude prompts may not be generated unless explicitly requested

Phase A Status: COMPLETE
Authority: GC_CLAUDE_FOUNDATION-A_CANON

No runtime behavior, execution logic, or Claude prompts generated per Phase A constraints.